### PR TITLE
Added recipe unlock advancements

### DIFF
--- a/src/main/resources/data/flesh2leather/advancements/recipes/combined_flesh.json
+++ b/src/main/resources/data/flesh2leather/advancements/recipes/combined_flesh.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "flesh2leather:combined_flesh"
+    ]
+  },
+  "criteria": {
+    "has_rotten_flesh": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:rotten_flesh"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "flesh2leather:combined_flesh"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_rotten_flesh",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/flesh2leather/advancements/recipes/smoking.json
+++ b/src/main/resources/data/flesh2leather/advancements/recipes/smoking.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "flesh2leather:smoking"
+    ]
+  },
+  "criteria": {
+    "has_combined_flesh": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "flesh2leather:combined_flesh"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "flesh2leather:smoking"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_combined_flesh",
+      "has_the_recipe"
+    ]
+  ]
+}


### PR DESCRIPTION
Added recipe unlock advancements so that the recipe for combined flesh is unlocked upon obtaining rotten flesh, and the recipe for smoking combined flesh is unlocked when it is obtained.